### PR TITLE
#23 - 에러 핸들러 구현 

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "cors": "^2.8.5",
     "css-loader": "^5.2.6",
     "dotenv": "^10.0.0",
-    "ejs": "^3.1.6",
     "express": "^4.17.1",
     "file-loader": "^6.2.0",
     "html-loader": "^2.1.2",

--- a/src/controllers/payment.ts
+++ b/src/controllers/payment.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import { IPayment, Payment } from "../models/Payment";
+import HttpError from "../errors/HttpError";
 
 interface IWritePaymentRequest extends Request {
   body: IPayment;
@@ -12,35 +13,24 @@ interface IRemovePaymentRequest extends Request {
 }
 
 export const readAll = async (req: Request, res: Response) => {
-  try {
-    const payments: Payment[] = await Payment.findAll();
+  const payments: Payment[] = await Payment.findAll();
 
-    res.status(200).json({ data: payments });
-  } catch (error) {
-    res.status(500).json({ error });
-  }
+  res.status(200).json({ data: payments });
 };
 
 export const write = async (req: IWritePaymentRequest, res: Response) => {
-  try {
-    const { value } = req.body;
-    const payment = await Payment.create({ value });
+  const { value } = req.body;
+  const payment = await Payment.create({ value });
 
-    res.status(200).json({ data: payment });
-  } catch (error) {
-    res.status(500).json({ error });
-  }
+  res.status(200).json({ data: payment });
 };
 
 export const remove = async (req: IRemovePaymentRequest, res: Response) => {
-  try {
-    const { id } = req.params;
-    if (!id || isNaN(Number(id))) {
-      res.status(400).json();
-    }
-    await Payment.destroy({ where: { id } });
-    res.status(203).json();
-  } catch (error) {
-    res.status(500).json({ error });
+  const { id } = req.params;
+  if (!id || isNaN(Number(id))) {
+    throw new HttpError(400, "없는 아이디입니다.");
   }
+  await Payment.destroy({ where: { id } });
+
+  res.status(203).json();
 };

--- a/src/errors/HttpError.ts
+++ b/src/errors/HttpError.ts
@@ -1,0 +1,8 @@
+export default class HttpError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,16 +3,12 @@ import cookieParser from "cookie-parser";
 import cors from "cors";
 import { config } from "dotenv";
 import express from "express";
-import path from "path";
 import { sequelize } from "./models";
 import rootRouter from "./router";
 
 config();
 sequelize.sync();
 const app = express();
-app.set("views", path.join(__dirname, "views"));
-app.set("view engine", "ejs");
-app.engine("html", require("ejs").renderFile);
 app.use(cors());
 app.use(express.static("dist"));
 app.use(bodyParser.json());

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { config } from "dotenv";
 import express from "express";
 import { sequelize } from "./models";
 import rootRouter from "./router";
+import errorMiddleware from "./middleware/errorMiddleware";
 
 config();
 sequelize.sync();
@@ -19,6 +20,7 @@ app.use(
 );
 app.use(cookieParser());
 app.use(rootRouter);
+app.use(errorMiddleware);
 
 app.listen(3000, () => {
   console.log("http://localhost:3000");

--- a/src/middleware/errorMiddleware.ts
+++ b/src/middleware/errorMiddleware.ts
@@ -1,0 +1,22 @@
+import { NextFunction, Request, Response } from "express";
+import HttpError from "../errors/HttpError";
+
+const errorMiddleware = (
+  error: Error,
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  console.log(error);
+  let status = 500;
+  let message = "Server Error: " + error.message;
+
+  if (error instanceof HttpError) {
+    status = error.status;
+    message = error.message;
+  }
+
+  res.status(status).json({ status, message });
+};
+
+export default errorMiddleware;

--- a/src/router/payment.ts
+++ b/src/router/payment.ts
@@ -1,10 +1,11 @@
 import express, { Router } from "express";
 import { readAll, remove, write } from "../controllers/payment";
+import wrapAsync from "../utils/wrapAsync";
 
 const paymentRouter: Router = express.Router();
 
-paymentRouter.get("/", readAll);
-paymentRouter.post("/", write);
-paymentRouter.delete("/:id", remove);
+paymentRouter.get("/", wrapAsync(readAll));
+paymentRouter.post("/", wrapAsync(write));
+paymentRouter.delete("/:id", wrapAsync(remove));
 
 export default paymentRouter;

--- a/src/utils/wrapAsync.ts
+++ b/src/utils/wrapAsync.ts
@@ -1,0 +1,8 @@
+import { NextFunction, Request, Response } from "express";
+
+const wrapAsync =
+  (fn: any) => (req: Request, res: Response, next: NextFunction) => {
+    fn(req, res, next).catch(next);
+  };
+
+export default wrapAsync;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1565,11 +1565,6 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
-async@0.9.x:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
-  integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
-
 async@^2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
@@ -1849,7 +1844,7 @@ caniuse-lite@^1.0.30001219:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001247.tgz#105be7a8fb30cdd303275e769a9dfb87d4b3577a"
   integrity sha512-4rS7co+7+AoOSPRPOPUt5/GdaqZc0EsUpWk66ofE3HJTAajUK2Ss2VwoNzVN69ghg8lYYlh0an0Iy4LIHHo9UQ==
 
-chalk@^2.0.0, chalk@^2.4.2:
+chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -2506,13 +2501,6 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-ejs@^3.1.6:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.6.tgz#5bfd0a0689743bb5268b3550cceeebbc1702822a"
-  integrity sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==
-  dependencies:
-    jake "^10.6.1"
-
 electron-to-chromium@^1.3.723:
   version "1.3.786"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.786.tgz#1fc572abc77e2f474725f8a61acf7e25ced9fbe2"
@@ -2937,13 +2925,6 @@ file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
-
-filelist@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.2.tgz#80202f21462d4d1c2e214119b1807c1bc0380e5b"
-  integrity sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==
-  dependencies:
-    minimatch "^3.0.4"
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -3860,16 +3841,6 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
-
-jake@^10.6.1:
-  version "10.8.2"
-  resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.2.tgz#ebc9de8558160a66d82d0eadc6a2e58fbc500a7b"
-  integrity sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==
-  dependencies:
-    async "0.9.x"
-    chalk "^2.4.2"
-    filelist "^1.0.1"
-    minimatch "^3.0.4"
 
 jest-worker@^27.0.2:
   version "27.0.6"


### PR DESCRIPTION
resolve #23 

- ejs가 안쓰이는 것 같아 지웠습니다. 현재 실행에 문제는 없는데, 혹여나 필요하거나 문제가 있다면 말씀부탁드려요.
- errorMiddleware를 통해 catch되지 않은 error를 status코드와 함께 res에 넣어줍니다.
- 현재는 payments router만 적용해두었습니다.

현재 방식이 괜찮으시다면, 다른 곳도 적용하면서 상황에 맞는 Error class를 만들까 합니다.
로그인 시 토큰에 따라 error를 내보내는 방식으로 다음 라우터로 가는 불필요한 로직을 줄일 수 있을 것 같네요.
의견 부탁드립니다.