### PR TITLE
#28 - 카테고리 모델 및 API 수정

### DIFF
--- a/src/controllers/category.ts
+++ b/src/controllers/category.ts
@@ -1,8 +1,22 @@
 import { Request, Response } from "express";
 import Category from "../models/Category";
+import RecordType from "../models/RecordType";
+import HttpError from "../errors/HttpError";
 
-export const readAll = async (req: Request, res: Response) => {
+interface IReadCategoryRequest extends Request {
+  query: {
+    type: RecordType;
+  };
+}
+
+export const readByType = async (req: IReadCategoryRequest, res: Response) => {
+  const { type } = req.query;
+  if (!Object.values(RecordType).includes(type)) {
+    throw new HttpError(400, "잘못된 타입입니다.");
+  }
+
   const categories: Category[] = await Category.findAll({
+    where: { type },
     attributes: ["id", "value", "type"],
   });
 

--- a/src/controllers/category.ts
+++ b/src/controllers/category.ts
@@ -1,13 +1,10 @@
 import { Request, Response } from "express";
-import Category, { ICategory } from "../models/Category";
+import Category from "../models/Category";
 
 export const readAll = async (req: Request, res: Response) => {
-  const categories: Category[] = await Category.findAll();
-  const data: ICategory[] = categories.map((category) => ({
-    id: category.id,
-    value: category.value,
-    type: category.type,
-  }));
+  const categories: Category[] = await Category.findAll({
+    attributes: ["id", "value", "type"],
+  });
 
-  res.status(200).json({ data });
+  res.status(200).json({ data: categories });
 };

--- a/src/controllers/category.ts
+++ b/src/controllers/category.ts
@@ -6,6 +6,7 @@ export const readAll = async (req: Request, res: Response) => {
   const data: ICategory[] = categories.map((category) => ({
     id: category.id,
     value: category.value,
+    type: category.type,
   }));
 
   res.status(200).json({ data });

--- a/src/controllers/record.ts
+++ b/src/controllers/record.ts
@@ -1,8 +1,9 @@
 import { Request, Response } from "express";
-import Record, { IRecord, RecordType } from "../models/Record";
+import Record, { IRecord } from "../models/Record";
 import Category from "../models/Category";
 import Payment from "../models/Payment";
 import HttpError from "../errors/HttpError";
+import RecordType from "../models/RecordType";
 
 interface IReadRecordRequest extends Request {
   query: {

--- a/src/models/Category.ts
+++ b/src/models/Category.ts
@@ -1,8 +1,10 @@
 import { AllowNull, Column, Model, Table, Unique } from "sequelize-typescript";
+import RecordType from "./RecordType";
 
 export interface ICategory {
   id?: number;
   value: string;
+  type: RecordType;
 }
 
 @Table
@@ -11,4 +13,8 @@ export default class Category extends Model<ICategory> {
   @Unique
   @Column
   value: string;
+
+  @AllowNull(false)
+  @Column
+  type: RecordType;
 }

--- a/src/models/Record.ts
+++ b/src/models/Record.ts
@@ -9,11 +9,7 @@ import {
 import Category from "./Category";
 import Payment from "./Payment";
 import User from "./user";
-
-export enum RecordType {
-  INCOME = "income",
-  EXPENSE = "expense",
-}
+import RecordType from "./RecordType";
 
 export interface IRecord {
   id?: number;

--- a/src/models/RecordType.ts
+++ b/src/models/RecordType.ts
@@ -1,0 +1,6 @@
+enum RecordType {
+  INCOME = "income",
+  EXPENSE = "expense",
+}
+
+export default RecordType;

--- a/src/models/defaultData.ts
+++ b/src/models/defaultData.ts
@@ -1,12 +1,15 @@
-export const CATEGORIES = [
-  "생활",
-  "식비",
-  "교통",
-  "쇼핑/뷰티",
-  "의료/건강",
-  "문화/여가",
-  "미분류",
-  "월급",
-  "용돈",
-  "기타수입",
+import RecordType from "./RecordType";
+import { ICategory } from "./Category";
+
+export const CATEGORIES: ICategory[] = [
+  { value: "생활", type: RecordType.EXPENSE },
+  { value: "식비", type: RecordType.EXPENSE },
+  { value: "교통", type: RecordType.EXPENSE },
+  { value: "쇼핑/뷰티", type: RecordType.EXPENSE },
+  { value: "의료/건강", type: RecordType.EXPENSE },
+  { value: "문화/여가", type: RecordType.EXPENSE },
+  { value: "미분류", type: RecordType.EXPENSE },
+  { value: "월급", type: RecordType.INCOME },
+  { value: "용돈", type: RecordType.INCOME },
+  { value: "기타수입", type: RecordType.INCOME },
 ];

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -21,9 +21,9 @@ const init = () => {
     const categories = await Category.findAll();
     const values = categories.map((category) => category.value);
     const notInsertedData = CATEGORIES.filter(
-      (category) => !values.includes(category)
+      (category) => !values.includes(category.value)
     );
-    notInsertedData.forEach((value) => Category.create({ value }));
+    notInsertedData.forEach((category) => Category.create(category));
   });
 };
 

--- a/src/router/category.ts
+++ b/src/router/category.ts
@@ -1,9 +1,9 @@
 import express, { Router } from "express";
-import { readAll } from "../controllers/category";
+import { readByType } from "../controllers/category";
 import wrapAsync from "../utils/wrapAsync";
 
 const categoryRouter: Router = express.Router();
 
-categoryRouter.get("/", wrapAsync(readAll));
+categoryRouter.get("/", wrapAsync(readByType));
 
 export default categoryRouter;


### PR DESCRIPTION
resolve #28 

- 카테고리에 type 컬럼을 추가했습니다.
- 카테고리 조회 시 queryParam으로 type을 받습니다

```json
GET http://localhost:3000/api/categories?type=income
Accept: application/json

// response
{
  "data": [
    {
      "id": 7,
      "value": "용돈",
      "type": "income"
    },
    {
      "id": 9,
      "value": "월급",
      "type": "income"
    },
    {
      "id": 10,
      "value": "기타수입",
      "type": "income"
    }
  ]
}

// income, expense 가 아닐 시
GET http://localhost:3000/api/categories?type=ee
Accept: application/json

{
  "status": 400,
  "message": "잘못된 타입입니다."
}
```
---

### 논의가 필요한 사항인 것 같습니다!

현재 피그마에는 분류가 지출에 관련된 것들만 보입니다.
수입/지출인지 판별하여 해당 드롭박스의 항목을 변경해야하나? 하는 생각에 작업을 했는데...
그냥 전체 카테고리를 보여주고 카테고리의 성격에 따라서 수입/지출을 선택해야할까요?
그렇다면 현재 PR은 그냥 close하면 될 것 같네요.

머지하신다면 내역 추가 기능에 수입/지출 선택 항목을 한가지 더 추가하시는 것으로 받아들이겠습니다.

추가적으로 전체 항목 호출 api도 필요하려나요?
지금은 type이 안받아져서 400 에러가 뜹니다.
