### PR TITLE
#56 - record api 리팩토링

### DIFF
--- a/src/controllers/record.ts
+++ b/src/controllers/record.ts
@@ -30,28 +30,29 @@ export const readByMonth = async (req: IReadRecordRequest, res: Response) => {
 
 const addYearCategory = async (record: IWriteRecordRequest["body"]) => {
   const { type, categoryId, year, amount, userId, month } = record;
-  if (type === "expense") {
-    let categoryIdString = categoryId.toString();
-    if (categoryIdString.length === 1) {
-      categoryIdString = "0" + categoryIdString;
-    }
-    const yearCategoryId = Number(
-      year.toString() + categoryIdString + userId.toString()
-    );
-    const yearCategory = await YearCategory.findByPk(yearCategoryId);
-    if (!yearCategory) {
-      await YearCategory.create<any>({
-        id: yearCategoryId,
-        [month]: amount,
-      });
-      return;
-    }
-
-    await YearCategory.increment(
-      { [month]: amount },
-      { where: { id: yearCategoryId } }
-    );
+  if (type === RecordType.INCOME) {
+    return;
   }
+  let categoryIdString = categoryId.toString();
+  if (categoryIdString.length === 1) {
+    categoryIdString = "0" + categoryIdString;
+  }
+  const yearCategoryId = Number(
+    year.toString() + categoryIdString + userId.toString()
+  );
+  const yearCategory = await YearCategory.findByPk(yearCategoryId);
+  if (!yearCategory) {
+    await YearCategory.create<any>({
+      id: yearCategoryId,
+      [month]: amount,
+    });
+    return;
+  }
+
+  await YearCategory.increment(
+    { [month]: amount },
+    { where: { id: yearCategoryId } }
+  );
 };
 
 const writeRecord = async (record: IRecord) => {

--- a/src/controllers/record.ts
+++ b/src/controllers/record.ts
@@ -72,10 +72,10 @@ export const write = async (req: IWriteRecordRequest, res: Response) => {
     }
   }
 
-  const _paymentId = await payment.id;
-  const req_body = await { ...req.body };
+  const _paymentId = payment.id;
+  const req_body = { ...req.body };
   req_body.paymentId = _paymentId;
-  const data: IRecord = await {
+  const data: IRecord = {
     ...req_body,
   };
   if (!Object.values(RecordType).includes(data.type)) {

--- a/src/controllers/record.ts
+++ b/src/controllers/record.ts
@@ -71,8 +71,7 @@ export const write = async (req: IWriteRecordRequest, res: Response) => {
   if (!Object.values(RecordType).includes(req.body.type)) {
     throw new HttpError(400, "잘못된 타입입니다.");
   }
-  await addYearCategory(req.body);
-  await writeRecord(req.body);
+  await Promise.all([addYearCategory(req.body), writeRecord(req.body)]);
 
   const records: Record[] = await Record.findAll({
     where: { month: req.body.month, userId: req.body.userId },

--- a/src/controllers/record.ts
+++ b/src/controllers/record.ts
@@ -25,7 +25,7 @@ export const readByMonth = async (req: IReadRecordRequest, res: Response) => {
   const records: Record[] = await Record.findAll({
     where: { month, userId },
     include: [Category, Payment],
-    order: [["date", "ASC"]],
+    order: [["createdAt", "DESC"]],
   });
   res.status(200).json({ data: records });
 };
@@ -96,7 +96,7 @@ export const write = async (req: IWriteRecordRequest, res: Response) => {
   const records: Record[] = await Record.findAll({
     where: { month: req.body.month, userId: req.body.userId },
     include: [Category, Payment],
-    order: [["date", "ASC"]],
+    order: [["createdAt", "DESC"]],
   });
   res.status(200).json({ data: records });
 };

--- a/src/util/wrapTransaction.ts
+++ b/src/util/wrapTransaction.ts
@@ -1,0 +1,7 @@
+import { sequelize } from "../models";
+import { Transaction } from "sequelize";
+
+const wrapTransaction = async (fns: (t: Transaction) => Promise<unknown>[]) =>
+  await sequelize.transaction((t) => Promise.all(fns(t)));
+
+export default wrapTransaction;


### PR DESCRIPTION
resolve #56 

- request / response의 변화는 없습니다.
  - order 기준을 createdAt으로 변경하긴 했습니다. 최신 내역이 가장 위로 올 수 있도록요. 어차피 날짜는 아예 분리가 되어서 date에 의한 order는 무의미한 것 같습니다.
- `wrapTransaction` 함수 내부에 포함된 함수들은 중간에 오류 발생 시 모든 작업을 롤백합니다.
  - `promise.all`로 실행하기 때문에 병렬적으로 처리됩니다.
  - 컨트롤러 전체를 감쌀 경우 response가 할당되지 않아 컨트롤러 함수 내부 일부만 적용하도록 했습니다.
  - 감싸진 부분은 실질적으로 service에 해당하는 부분입니다만, 분리하기 시작하면 구조 변경이 너무 오래 걸릴 것 같아 적당히 함수만 분리하고 말았습니다.

이후 다른 api도 transaction 설정이 필요해보이는 경우 작업하도록 하겠습니다.