### PR TITLE
#60 - auth api 리팩토링

### DIFF
--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -24,7 +24,7 @@ export const login = async (req: Request, res: Response) => {
   const { username, password } = req.body;
   if (!username || !password)
     throw new HttpError(400, "이름과 비밀번호를 정확히 입력해 주세요");
-  const user = await User.findOne({ where: { username: username } });
+  const user = await User.findOne({ where: { username } });
   // 계정이 존재하는지
   if (!user) throw new HttpError(400, "같은 이름의 계정이 존재하지 않습니다.");
   // 비밀번호가 일치하지 않음
@@ -44,11 +44,7 @@ export const register = async (req: Request, res: Response) => {
   const { username, password, email } = req.body;
 
   const hashedPassword = await bcrypt.hash(password.toString(), 10);
-  const user = await User.create({
-    username: username,
-    email: email,
-    hashedPassword: hashedPassword,
-  });
+  const user = await User.create({ username, email, hashedPassword });
   const serialized = await serialize(user);
   const token = await generateToken(user);
   res.set("token", token);

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -47,8 +47,11 @@ export const login = async (req: Request, res: Response) => {
 
 export const register = async (req: Request, res: Response) => {
   const { username, password, email } = req.body;
+  if (!username || !password || !email) {
+    throw new HttpError(400, "입력되지 않은 값이 있습니다.");
+  }
 
-  const hashedPassword = await bcrypt.hash(password.toString(), 10);
+  const hashedPassword = await bcrypt.hash(password, 10);
   const user = await User.create({ username, email, hashedPassword });
   const serialized = await serialize(user);
   const token = await generateToken(user);

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -1,6 +1,5 @@
 import bcrypt from "bcryptjs";
 import { Request, Response } from "express";
-import { Model } from "sequelize-typescript";
 import User from "../models/User";
 import HttpError from "../errors/HttpError";
 import { generateToken } from "../util/generateToken";
@@ -16,22 +15,28 @@ interface IUpdateUserImgRequest extends IAuthRequest {
 export const check = async (req: IAuthRequest, res: Response) => {
   const { userId } = req.body;
   const user = await User.findByPk(userId);
-  if (!user) throw new HttpError(400, "같은 이름의 계정이 존재하지 않습니다.");
+  if (!user) {
+    throw new HttpError(401, "같은 이름의 계정이 존재하지 않습니다.");
+  }
   res.status(200).json({ data: user });
 };
 
 export const login = async (req: Request, res: Response) => {
   const { username, password } = req.body;
-  if (!username || !password)
+  if (!username || !password) {
     throw new HttpError(400, "이름과 비밀번호를 정확히 입력해 주세요");
+  }
   const user = await User.findOne({ where: { username } });
-  // 계정이 존재하는지
-  if (!user) throw new HttpError(400, "같은 이름의 계정이 존재하지 않습니다.");
-  // 비밀번호가 일치하지 않음
+  if (!user) {
+    throw new HttpError(401, "같은 이름의 계정이 존재하지 않습니다.");
+  }
+
   const hashedPassword = user.getDataValue("hashedPassword");
   const valid = await bcrypt.compare(password, hashedPassword);
-  if (!valid) throw new HttpError(400, "비밀번호가 잘못되었습니다");
-  // 토큰 발급
+  if (!valid) {
+    throw new HttpError(401, "비밀번호가 잘못되었습니다");
+  }
+
   const serialized = await serialize(user);
   const token = await generateToken(user);
   res.set("token", token);

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -43,26 +43,7 @@ export const login = async (req: Request, res: Response) => {
 
 export const register = async (req: Request, res: Response) => {
   const { username, password, email } = req.body;
-  // 에러처리
-  if (!username || !password || !email) {
-    const table: any = {
-      username: username,
-      password: password,
-      email: email,
-    };
-    const blanks = [];
-    for (const blank of ["username", "password", "email"]) {
-      if (!table[blank]) blanks.push(blank);
-    }
-    throw new HttpError(400, `${blanks.join(", ")}을 올바르게 입력해 주세요`);
-  }
-  // 에러처리 (이미 존재하는 계정)
-  const nameExists = await User.findOne({ where: { username: username } });
-  if (nameExists) throw new HttpError(400, "같은 이름의 계정이 존재합니다.");
-  // 에러처리 (이미 존재하는 이메일)
-  const emailExists = await User.findOne({ where: { email: email } });
-  if (emailExists) throw new HttpError(400, "이미 가입된 이메일입니다.");
-  // 패스워드 제네레이터
+
   const hashedPassword = await bcrypt.hash(password.toString(), 10);
   const user = await User.create<Model>({
     username: username,

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -44,7 +44,7 @@ export const register = async (req: Request, res: Response) => {
   const { username, password, email } = req.body;
 
   const hashedPassword = await bcrypt.hash(password.toString(), 10);
-  const user = await User.create<Model>({
+  const user = await User.create({
     username: username,
     email: email,
     hashedPassword: hashedPassword,

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -18,7 +18,8 @@ export const check = async (req: IAuthRequest, res: Response) => {
   if (!user) {
     throw new HttpError(401, "같은 이름의 계정이 존재하지 않습니다.");
   }
-  res.status(200).json({ data: user });
+  const serialized = await serialize(user);
+  res.status(200).json({ data: serialized });
 };
 
 export const login = async (req: Request, res: Response) => {

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -25,7 +25,7 @@ export const check = async (req: IAuthRequest, res: Response) => {
 export const login = async (req: Request, res: Response) => {
   const { username, password } = req.body;
   if (!username || !password) {
-    throw new HttpError(400, "이름과 비밀번호를 정확히 입력해 주세요");
+    throw new HttpError(400, "이름과 비밀번호를 모두 입력해 주세요");
   }
   const user = await User.findOne({ where: { username } });
   if (!user) {

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -34,7 +34,6 @@ export const login = async (req: Request, res: Response) => {
   // 토큰 발급
   const serialized = await serialize(user);
   const token = await generateToken(user);
-  if (!token) throw new HttpError(400, "토큰 생성 실패");
   res.set("token", token);
   res.setHeader("Access-Control-Expose-Headers", "*");
   res.setHeader("Access-Control-Allow-Origin", "*");
@@ -52,7 +51,6 @@ export const register = async (req: Request, res: Response) => {
   });
   const serialized = await serialize(user);
   const token = await generateToken(user);
-  if (!token) throw new HttpError(400, "토큰 생성 실패");
   res.set("token", token);
   res.setHeader("Access-Control-Expose-Headers", "*");
   res.setHeader("Access-Control-Allow-Origin", "*");

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -40,8 +40,6 @@ export const login = async (req: Request, res: Response) => {
   const serialized = await serialize(user);
   const token = await generateToken(user);
   res.set("token", token);
-  res.setHeader("Access-Control-Expose-Headers", "*");
-  res.setHeader("Access-Control-Allow-Origin", "*");
   res.status(200).json({ data: serialized });
 };
 
@@ -56,8 +54,6 @@ export const register = async (req: Request, res: Response) => {
   const serialized = await serialize(user);
   const token = await generateToken(user);
   res.set("token", token);
-  res.setHeader("Access-Control-Expose-Headers", "*");
-  res.setHeader("Access-Control-Allow-Origin", "*");
   res.status(200).json({ data: serialized });
 };
 

--- a/src/controllers/github.ts
+++ b/src/controllers/github.ts
@@ -75,9 +75,5 @@ export const githubtoken = async (req: any, res: Response) => {
   const token = await generateToken(user);
   res.set("token", token);
   res.status(200).json({ data: serialized });
-  req.session.destroy(function (err: string) {
-    if (err) {
-      return;
-    }
-  });
+  req.session.destroy();
 };

--- a/src/controllers/github.ts
+++ b/src/controllers/github.ts
@@ -52,13 +52,13 @@ export const githubtoken = async (req: any, res: Response) => {
   if (!data) {
     throw new HttpError(403, "세션이 없습니다");
   }
-  let user = await User.findOne<Model>({ where: { username: data.login } });
+  let user = await User.findOne({ where: { username: data.login } });
   const username = data.login;
   const password = data.id.toString();
   const img = data.avatar_url;
   if (!user) {
     const hashedPassword = await bcrypt.hash(password.toString(), 10);
-    user = await User.create<Model>({
+    user = await User.create({
       username,
       email: "",
       hashedPassword,
@@ -73,9 +73,6 @@ export const githubtoken = async (req: any, res: Response) => {
   // 로그인 발급
   const serialized = await serialize(user);
   const token = await generateToken(user);
-  if (!token) throw new HttpError(500, "토큰 생성 실패");
-  const CLIENT_URL = process.env.CLIENT_URL;
-  if (!CLIENT_URL) throw new HttpError(500, "헤더 생성 실패");
   res.set("token", token);
   res.setHeader("Access-Control-Expose-Headers", "*");
   res.setHeader("Access-Control-Allow-Origin", "*");

--- a/src/controllers/github.ts
+++ b/src/controllers/github.ts
@@ -1,7 +1,6 @@
 import bcrypt from "bcryptjs";
 import { Request, Response } from "express";
 import fetch from "node-fetch";
-import { Model } from "sequelize-typescript";
 import HttpError from "../errors/HttpError";
 import User from "../models/User";
 import { generateToken } from "../util/generateToken";

--- a/src/controllers/github.ts
+++ b/src/controllers/github.ts
@@ -74,8 +74,6 @@ export const githubtoken = async (req: any, res: Response) => {
   const serialized = await serialize(user);
   const token = await generateToken(user);
   res.set("token", token);
-  res.setHeader("Access-Control-Expose-Headers", "*");
-  res.setHeader("Access-Control-Allow-Origin", "*");
   res.status(200).json({ data: serialized });
   req.session.destroy(function (err: string) {
     if (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,11 +6,13 @@ import expressSession from "express-session";
 import errorMiddleware from "./middleware/errorMiddleware";
 import { sequelize } from "./models";
 import rootRouter from "./router";
+import corsMiddleware from "./middleware/corsMiddleware";
 
 config();
 sequelize.sync();
 const app = express();
 app.use(cors());
+app.use(corsMiddleware);
 app.use(express.static("dist"));
 app.use(express.json());
 app.use(

--- a/src/middleware/corsMiddleware.ts
+++ b/src/middleware/corsMiddleware.ts
@@ -1,0 +1,9 @@
+import { NextFunction, Request, Response } from "express";
+
+const corsMiddleware = (req: Request, res: Response, next: NextFunction) => {
+  res.setHeader("Access-Control-Expose-Headers", "*");
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  next();
+};
+
+export default corsMiddleware;

--- a/src/middleware/errorMiddleware.ts
+++ b/src/middleware/errorMiddleware.ts
@@ -1,5 +1,22 @@
 import { NextFunction, Request, Response } from "express";
 import HttpError from "../errors/HttpError";
+import { BaseError, UniqueConstraintError } from "sequelize";
+
+const handleDBError = (error: BaseError, res: Response) => {
+  let status = 500;
+  let message = "DB Error: " + error.message;
+
+  if (error instanceof UniqueConstraintError) {
+    status = 400;
+    message =
+      "DB Unique Error: " +
+      Object.keys(error.fields)
+        .map((field) => field.split(".")[1])
+        .join(", ") +
+      "이(가) 중복됩니다.";
+  }
+  res.status(status).json({ status, message });
+};
 
 const errorMiddleware = (
   error: Error,
@@ -11,6 +28,10 @@ const errorMiddleware = (
   let status = 500;
   let message = "Server Error: " + error.message;
 
+  if (error instanceof BaseError) {
+    handleDBError(error, res);
+    return;
+  }
   if (error instanceof HttpError) {
     status = error.status;
     message = error.message;

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -5,7 +5,7 @@ export interface IUser {
   username: string;
   email: string;
   hashedPassword: string;
-  img: string;
+  img?: string;
 }
 
 @Table
@@ -23,6 +23,7 @@ export default class User extends Model<IUser> {
   @Column
   hashedPassword: string;
 
+  @AllowNull
   @Column
   img: string;
 }

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,4 +1,4 @@
-import { Column, Model, Table } from "sequelize-typescript";
+import { AllowNull, Column, Model, Table, Unique } from "sequelize-typescript";
 
 export interface IUser {
   id?: string;
@@ -10,9 +10,13 @@ export interface IUser {
 
 @Table
 export default class User extends Model<IUser> {
+  @AllowNull(false)
+  @Unique
   @Column
   username: string;
 
+  @AllowNull(false)
+  @Unique
   @Column
   email: string;
 

--- a/src/util/generateToken.ts
+++ b/src/util/generateToken.ts
@@ -1,8 +1,9 @@
 import jwt from "jsonwebtoken";
 import HttpError from "../errors/HttpError";
+import User from "../models/User";
 
 // 토큰 발급
-export const generateToken = (user: any): string => {
+export const generateToken = (user: User): string => {
   const jwt_secret: string | undefined = process.env.JWT_SECRET;
   if (!jwt_secret) {
     throw new HttpError(400, "토큰 생성 실패");

--- a/src/util/generateToken.ts
+++ b/src/util/generateToken.ts
@@ -1,10 +1,13 @@
 import jwt from "jsonwebtoken";
+import HttpError from "../errors/HttpError";
 
 // 토큰 발급
-export const generateToken = (user: any) => {
+export const generateToken = (user: any): string => {
   const jwt_secret: string | undefined = process.env.JWT_SECRET;
-  if (!jwt_secret) return null;
-  const token = jwt.sign(
+  if (!jwt_secret) {
+    throw new HttpError(400, "토큰 생성 실패");
+  }
+  return jwt.sign(
     {
       id: user.id,
       username: user.username,
@@ -14,5 +17,4 @@ export const generateToken = (user: any) => {
       expiresIn: process.env.JWT_EXPIRED,
     }
   );
-  return token;
 };


### PR DESCRIPTION
resolve #60 

- 중복 데이터를 model에서 unique를 통해 검출하도록 했습니다.
- generateToken 함수를 일부 수정했습니다.
  - User만을 받을 수 있습니다
  - null을 반환하지 않고 오류 발생 시 내부에서 throw하도록 합니다.
- auth 내 오류 발생 시 status code를 변경했습니다.
  - 401은 허용되지 않은 사용자, 즉 로그인 하기 이전에 로그인 실패 등을 의미합니다.
- DB 에러 핸들링을 별도로 진행합니다.
  - 기존의 에러핸들러에서 if 분기를 통해 작동합니다.
- corsMiddleware를 통해 response 헤더 설정을 전체적으로 적용합니다.
  - 실행 환경을 받아 적용 여부를 결정하거나, 그냥 배포 전에 삭제해도 됩니다.